### PR TITLE
Account for differences in Apple Music xml file

### DIFF
--- a/src/xml_reader/tracks.rs
+++ b/src/xml_reader/tracks.rs
@@ -13,6 +13,16 @@ use crate::{
 
 use super::LibraryXmlReader;
 
+/// List of keys to ignore during track XML processing.
+const IGNORED_KEYS: &[&str] = &[
+    "Purchased",
+    "Explicit",
+    "Playlist Only",
+    "Disliked",
+    "Sort Series",
+    "Clean",
+];
+
 #[rustfmt::skip]
 pub fn get_track(reader: &mut xml_reader::LibraryXmlReader) -> Result<Track, err::LibraryXmlReader> {
     let _ = reader.forward();
@@ -23,73 +33,79 @@ pub fn get_track(reader: &mut xml_reader::LibraryXmlReader) -> Result<Track, err
                 let key = reader.element_as_string(Some("key"))?;
                 let value = reader.element_as_string(None)?;
                 match key.as_str() {
-
                     "Album Artist" => the_track.album_artist = Some(value),
-                    "Album Rating Computed" => {}
+                    "Album Rating Computed" => {},
                     "Album Rating" => the_track.album_rating = Some(value.parse::<usize>()?),
                     "Album" => the_track.album_title = Some(value),
                     "Artist" => the_track.artist = Some(value),
-                    "Artwork Count" => {}
+                    "Artwork Count" => {},
                     "BPM" => the_track.bpm = Some(value.parse::<usize>()?),
-                    "Bit Rate" => {}
+                    "Bit Rate" => {},
                     "Comments" => the_track.comments = Some(value),
                     "Compilation" => the_track.compiltion = true,
                     "Composer" => the_track.composer = Some(value),
                     "Date Added" => the_track.date_added = value.parse::<DateTime<Utc>>()?,
                     "Date Modified" => the_track.date_modified = value.parse::<DateTime<Utc>>()?,
-                    "Disabled" => {}
+                    "Disabled" => {},
                     "Disc Count" => the_track.disc_count = Some(value.parse::<usize>()?),
                     "Disc Number" => the_track.disc_number = Some(value.parse::<usize>()?),
                     "Favorited" => the_track.favourited = true,
-                    "File Folder Count" => {}
+                    "File Folder Count" => {},
                     "Genre" => the_track.genre = Some(value),
                     "Grouping" => the_track.grouping = Some(value),
-                    "Kind" => {}
-                    "Library Folder Count" => {}
+                    "Kind" => {},
+                    "Library Folder Count" => {},
                     "Location" => the_track.location = value,
                     "Loved" => the_track.loved = true,
-                    "Movement Count" => {}
+                    "Movement Count" => {},
                     "Movement Name" => the_track.movement_title = Some(value),
                     "Movement Number" => the_track.movement_number = Some(value.parse::<usize>()?),
                     "Name" => the_track.title = Some(value),
-                    "Normalization" => {}
-                    "Part Of Gapless Album" => {}
+                    "Normalization" => {},
+                    "Part Of Gapless Album" => {},
                     "Persistent ID" => the_track.persistent_id = value,
                     "Play Count" => the_track.play_count = value.parse::<usize>()?,
                     "Play Date UTC" => the_track.play_date = Some(value.parse::<DateTime<Utc>>()?),
-                    "Play Date" => {} // use utc variant
-                    "Rating Computed" => {}
+                    "Play Date" => {}, // use utc variant
+                    "Rating Computed" => {},
                     "Rating" => the_track.rating = value.parse::<usize>()?,
                     "Release Date" => the_track.release_data = Some(value.parse::<DateTime<Utc>>()?),
-                    "Sample Rate" => {}
+                    "Sample Rate" => {},
                     "Size" => the_track.size = value.parse::<usize>()?,
                     "Skip Count" => the_track.skip_count = value.parse::<usize>()?,
                     "Skip Date" => the_track.skip_date = Some(value.parse::<DateTime<Utc>>()?),
-                    "Sort Album Artist" => {}
-                    "Sort Album" => {}
-                    "Sort Artist" => {}
-                    "Sort Composer" => {}
-                    "Sort Name" => {}
+                    "Sort Album Artist" => {},
+                    "Sort Album" => {},
+                    "Sort Artist" => {},
+                    "Sort Composer" => {},
+                    "Sort Name" => {},
                     "Total Time" => the_track.duration = Duration::from_millis(value.parse::<u64>()?),
                     "Track Count" => the_track.total_tracks = Some(value.parse::<usize>()?),
                     "Track ID" => the_track.id = value,
                     "Track Number" => the_track.track_number = Some(value.parse::<usize>()?),
-                    "Track Type" => {}
-                    "Volume Adjustment" => {}
+                    "Track Type" => {},
+                    "Volume Adjustment" => {},
                     "Work" => the_track.work = Some(value),
                     "Year" => the_track.year = Some(value.parse::<usize>()?),
-
-                    // missed something?
+                    // For any unknown key, if it's in IGNORED_KEYS or not recognized, log and skip.
                     _ => {
-                        let title = match &the_track.title {
-                            Some(found) => found,
-                            None => "[No title]"
-                        };
-                        let artist = match &the_track.artist {
-                            Some(found) => found,
-                            None => "[No artist]",
-                        };
-                        println!("Unexpected key:\n\t\"{key}\" with value\n\t\"{value}\"\nwhen reading{title} by {artist}.");
+                        if IGNORED_KEYS.contains(&key.as_str()) {
+                            log::debug!(
+                                "Ignoring track key '{}' with value '{}' in track '{}'",
+                                key,
+                                value,
+                                the_track.title.as_deref().unwrap_or("[No title]")
+                            );
+                        } else {
+                            log::debug!(
+                                "Ignoring unexpected track key '{}' with value '{}' in track '{}' by '{}'",
+                                key,
+                                value,
+                                the_track.title.as_deref().unwrap_or("[No title]"),
+                                the_track.artist.as_deref().unwrap_or("[No artist]")
+                            );
+                        }
+                        continue;
                     }
                 }
             }
@@ -107,7 +123,7 @@ pub fn get_track(reader: &mut xml_reader::LibraryXmlReader) -> Result<Track, err
                     }
                 }
             }
-            _ => {}
+            _ => { let _ = reader.forward(); continue; }
         }
     }
     Ok(the_track)
@@ -118,12 +134,11 @@ impl Library {
         &mut self,
         reader: &mut LibraryXmlReader,
     ) -> Result<(), xml_reader::err::LibraryXmlReader> {
-        // process each track
+        // Process each track in the tracks dictionary.
         reader.eat_start("dict")?;
         loop {
             match reader.peek() {
                 XmlEvent::StartElement { name, .. } => {
-                    //
                     match name.local_name.as_str() {
                         "key" => {
                             let id = reader.element_as_string(Some("key"))?;
@@ -143,7 +158,7 @@ impl Library {
                     reader.eat_end("dict")?;
                     break;
                 }
-                _ => {}
+                _ => { let _ = reader.forward(); continue; }
             }
         }
         Ok(())


### PR DESCRIPTION
My Library.xml had quite a few keys that apparently did not appear in yours. The version of Apple Music I have is 1.5.2.56 though I don't think that is the reason. Is your xml file from a takeout request for your data from Apple?

Anyway, this mostly worked after making changes to playlists.rs and tracks.rs

There were still around 2500 tracks that did not match, but that is not so bad... it leaves about 250 tracks with ratings that I suppose I should manually change, unless I fix the matching...